### PR TITLE
Sean Hyde & Ethan Tamang

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -28,7 +28,7 @@ export type LeaderboardEntry = {
 export async function is_game_ready() {
 	const now = new Date();
 	const start = new Date(1731160800000); // November 9, 2024 10:00:00 AM
-	const end = new Date(1731254400000+86400000); // November 10, 2024 11:00:00 AM
+	const end = new Date(1731254400000 + 86400000); // November 10, 2024 11:00:00 AM
 
 	return now >= start && now <= end;
 }
@@ -62,13 +62,7 @@ export async function get_leaderboard() {
 	return data.map((entry) => entry as LeaderboardEntry);
 }
 
-export async function create_leaderboard_entry({
-	username,
-	score,
-}: {
-	username: string;
-	score: number;
-}) {
+export async function create_leaderboard_entry({ username, score }: { username: string; score: number }) {
 	const profanity = new Profanity({
 		wholeWord: false,
 		languages: ["en", "de", "es", "fr"],
@@ -80,12 +74,7 @@ export async function create_leaderboard_entry({
 		return { status: 401, message: "Usernames must be alphanumeric and less than 20 characters." };
 	}
 
-	if (
-		score < 0 ||
-		score > 200000 ||
-		isNaN(score) ||
-		score % 2 !== 0
-	) {
+	if (score < 0 || score > 200000 || isNaN(score) || score % 2 !== 0) {
 		return { status: 401, message: "Invalid score." };
 	}
 

--- a/components/title-components/title-text.tsx
+++ b/components/title-components/title-text.tsx
@@ -29,7 +29,7 @@ export default function TitleText() {
 	return (
 		<div className="w-full font-sans  text-left flex items-start justify-center flex-col mb-8">
 			<h1 className="w-full text-5xl 2xs:text-7xl sm:text-8xl 2xl:text-9xl font-bold">HACKRPI</h1>
-			<h2 className="w-full text-4xl sm:text-[3.5rem] 2xl:text-7xl whitespace-nowrap h-14 2xl:h-20">Urban Upgrades</h2>
+			<h2 className="w-full text-4xl sm:text-[3.5rem] 2xl:text-7xl whitespace-nowrap h-14 2xl:h-20">Retro V. Modern</h2>
 			<p className={`w-full text-3xl sm:text-4xl 2xl:text-5xl mb-8`}>
 				November 9-10, <span onMouseEnter={() => setYear(1824)}>{year}</span>
 			</p>

--- a/components/title-components/title-text.tsx
+++ b/components/title-components/title-text.tsx
@@ -29,7 +29,7 @@ export default function TitleText() {
 	return (
 		<div className="w-full font-sans  text-left flex items-start justify-center flex-col mb-8">
 			<h1 className="w-full text-5xl 2xs:text-7xl sm:text-8xl 2xl:text-9xl font-bold">HACKRPI</h1>
-			<h2 className="w-full text-4xl sm:text-[3.5rem] 2xl:text-7xl whitespace-nowrap h-14 2xl:h-20">Retro V. Modern</h2>
+			<h2 className="w-full text-4xl sm:text-[3.5rem] 2xl:text-7xl whitespace-nowrap h-14 2xl:h-20">Urban Upgrades</h2>
 			<p className={`w-full text-3xl sm:text-4xl 2xl:text-5xl mb-8`}>
 				November 9-10, <span onMouseEnter={() => setYear(1824)}>{year}</span>
 			</p>


### PR DESCRIPTION
# Changed header text to the correct theme "Retro V. Modern"




<img width="483" alt="Screenshot 2025-01-24 at 4 58 15 PM" src="https://github.com/user-attachments/assets/44614e85-2ac3-4f3a-a20f-3066663ff8ab" />

