### PR TITLE
Announcement Page

### DIFF
--- a/app/announcements/page.tsx
+++ b/app/announcements/page.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import React from "react";
+import "@/app/globals.css";
+import Footer from "@/components/footer/footer";
+import NavBar from "@/components/nav-bar/nav-bar";
+
+export default function Announcements() 
+{
+  return (
+    <>
+      <NavBar showOnScroll={false} />
+
+      <div className="justify-center flex w-full flex-col bg-hackrpi-dark-blue pt-24 desktop:pt-16 min-h-screen">
+        <div className="container mx-auto p-8">
+          <h1 className="text-4xl font-bold text-hackrpi-orange mb-4">
+            Announcements
+          </h1>
+          <p className="text-hackrpi-yellow text-lg">
+            Stay updated with the latest HackRPI announcements here.
+          </p>
+
+          {/* Example Announcement */}
+          <div className="mt-6 p-4 border border-hackrpi-orange bg-opacity-20 bg-hackrpi-yellow rounded-lg">
+            <h2 className="text-2xl font-semibold text-hackrpi-orange">
+              🚀 HackRPI 2024 Schedule is Live!
+            </h2>
+            <p className="text-hackrpi-yellow">
+              Check out the event schedule for updated informtion!
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <Footer />
+    </>
+  );
+}

--- a/components/interactive-map/interactive-map.tsx
+++ b/components/interactive-map/interactive-map.tsx
@@ -5,6 +5,7 @@ import NextLink from "next/link";
 const links: Link[] = [
 	{ href: "/event", children: "Event Information" },
 	{ href: "/event/schedule", children: "Schedule" },
+	{ href: "/announcements", children: "Announcements" },
 	{ href: "/event/prizes", children: "Prizes" },
 	{ href: "/resources", children: "Resources" },
 	{ href: "/last-year", children: "HackRPI XII" },
@@ -13,6 +14,7 @@ const links: Link[] = [
 const firsthalflink: Link[] = [
 	{ href: "/event", children: "Event Information" },
 	{ href: "/event/schedule", children: "Schedule" },
+	{ href: "/announcements", children: "Announcements" },
 	{ href: "/event/prizes", children: "Prizes" },
 ];
 const secondhalflink: Link[] = [

--- a/components/nav-bar/desktop/nav-bar-desktop.tsx
+++ b/components/nav-bar/desktop/nav-bar-desktop.tsx
@@ -39,6 +39,12 @@ export default function DesktopNavBar({ links }: { links: NavGroup[] }) {
 						Schedule
 					</Link>
 					<Link
+						href="/announcements"
+						className="mx-2 whitespace-nowrap text-lg xl:text-xl bg-[length:0%_2px] bg-no-repeat bg-left-bottom transition-all duration-200 bg-gradient-to-r from-hackrpi-yellow to-hackrpi-yellow hover:bg-[length:100%_2px]"
+					>
+						Announcements
+					</Link>
+					<Link
 						href="/event/prizes"
 						className="mx-2 whitespace-nowrap text-lg xl:text-xl bg-[length:0%_2px] bg-no-repeat bg-left-bottom transition-all duration-200 bg-gradient-to-r from-[#e9bc59] to-[#d5345d] hover:bg-[length:100%_2px]"
 					>

--- a/components/socials-links/social-links.tsx
+++ b/components/socials-links/social-links.tsx
@@ -1,12 +1,14 @@
 import Card, { CardProps } from "./socials-card";
 
+
 const socialLinks: CardProps[] = [
 	{
 		svgPath: "/social/instagram.svg",
 		link: "https://www.instagram.com/hack.rpi/",
 		name: "Instagram",
-		bgGradientFrom: "from-[#FD1D1D]",
-		bgGradientTo: "to-[#405DE6]",
+		bgGradientFrom: "from-[#feda75]",  // Light yellow/orange
+    	bgGradientVia: "via-[#d62976]",   // Pink/magenta
+    	bgGradientTo: "to-[#4f5bd5]",     // Deep blue/purple
 	},
 	{
 		svgPath: "/social/discord.svg",

--- a/components/socials-links/socials-card.tsx
+++ b/components/socials-links/socials-card.tsx
@@ -5,6 +5,7 @@ export type CardProps = {
 	link: string;
 	name: string;
 	bgGradientFrom: string;
+	bgGradientVia?: string;
 	bgGradientTo: string;
 	classname?: string;
 };


### PR DESCRIPTION
Announcement Page

Created an Announcements Page for furture announcements, added the new page to the Header Bar after Schedule, and added it to the interactive map on Home Page with @pdcarlson 


<img width="1710" alt="Screenshot 2025-02-25 at 5 42 17 PM" src="https://github.com/user-attachments/assets/f4efc7e3-4c9b-4626-a110-81db8c5db1a1" />
<img width="1710" alt="Screenshot 2025-02-25 at 5 42 28 PM" src="https://github.com/user-attachments/assets/12b412ba-8a9a-4358-82c8-780d5d22b82b" />
<img width="1710" alt="Screenshot 2025-02-25 at 5 42 40 PM" src="https://github.com/user-attachments/assets/c049ef94-3baf-421d-aa48-3e9815270553" /> 