### PR TITLE
Updated all options in header to match

### DIFF
--- a/components/nav-bar/desktop/nav-bar-desktop.tsx
+++ b/components/nav-bar/desktop/nav-bar-desktop.tsx
@@ -7,7 +7,7 @@ import Link from "next/link";
 
 export default function DesktopNavBar({ links }: { links: NavGroup[] }) {
 	return (
-		<div className="bg-gradient-to-r from-hackrpi-light-purple via-hackrpi-pink to-hackrpi-light-purple w-full h-16">
+		<div className = "bg-gradient-to-r from-hackrpi-light-purple via-hackrpi-pink to-hackrpi-light-purple w-full h-16">
 			<div className="flex justify-center lg:justify-center items-center h-full">
 				<div className="flex items-center justify-center mr-4">
 					<Link href="/" className="w-fit whitespace-nowrap">
@@ -22,43 +22,43 @@ export default function DesktopNavBar({ links }: { links: NavGroup[] }) {
 					))}
 					<Link
 						href="/sponsor-us"
-						className="mx-2 whitespace-nowrap text-lg xl:text-xl bg-[length:0%_2px] bg-no-repeat bg-left-bottom transition-all duration-200 bg-gradient-to-r from-hackrpi-yellow to-hackrpi-yellow hover:bg-[length:100%_2px]"
+						className="mx-2 whitespace-nowrap text-lg xl:text-xl bg-[length:0%_2px] bg-no-repeat bg-left-bottom transition-all duration-200 bg-gradient-to-r from-hackrpi-yellow to-hackrpi-pink hover:bg-[length:100%_2px]"
 					>
 						Sponsor Us
 					</Link>
 					<Link
 						href="/event"
-						className="mx-2 whitespace-nowrap text-lg xl:text-xl bg-[length:0%_2px] bg-no-repeat bg-left-bottom transition-all duration-200 bg-gradient-to-r from-[#e9bc59] to-[#d5345d] hover:bg-[length:100%_2px]"
+						className="mx-2 whitespace-nowrap text-lg xl:text-xl bg-[length:0%_2px] bg-no-repeat bg-left-bottom transition-all duration-200 bg-gradient-to-r from-hackrpi-yellow to-hackrpi-pink hover:bg-[length:100%_2px]"
 					>
 						Event Info
 					</Link>
 					<Link
 						href="/event/schedule"
-						className="mx-2 whitespace-nowrap text-lg xl:text-xl bg-[length:0%_2px] bg-no-repeat bg-left-bottom transition-all duration-200 bg-gradient-to-r from-[#e9bc59] to-[#d5345d] hover:bg-[length:100%_2px]"
+						className="mx-2 whitespace-nowrap text-lg xl:text-xl bg-[length:0%_2px] bg-no-repeat bg-left-bottom transition-all duration-200 bg-gradient-to-r from-hackrpi-yellow to-hackrpi-pink hover:bg-[length:100%_2px]"
 					>
 						Schedule
 					</Link>
 					<Link
 						href="/announcements"
-						className="mx-2 whitespace-nowrap text-lg xl:text-xl bg-[length:0%_2px] bg-no-repeat bg-left-bottom transition-all duration-200 bg-gradient-to-r from-hackrpi-yellow to-hackrpi-yellow hover:bg-[length:100%_2px]"
+						className="mx-2 whitespace-nowrap text-lg xl:text-xl bg-[length:0%_2px] bg-no-repeat bg-left-bottom transition-all duration-200 bg-gradient-to-r from-hackrpi-yellow to-hackrpi-pink hover:bg-[length:100%_2px]"
 					>
 						Announcements
 					</Link>
 					<Link
 						href="/event/prizes"
-						className="mx-2 whitespace-nowrap text-lg xl:text-xl bg-[length:0%_2px] bg-no-repeat bg-left-bottom transition-all duration-200 bg-gradient-to-r from-[#e9bc59] to-[#d5345d] hover:bg-[length:100%_2px]"
+						className="mx-2 whitespace-nowrap text-lg xl:text-xl bg-[length:0%_2px] bg-no-repeat bg-left-bottom transition-all duration-200 bg-gradient-to-r from-hackrpi-yellow to-hackrpi-pink hover:bg-[length:100%_2px]"
 					>
 						Prizes
 					</Link>
 					<Link
 						href="/2048/leaderboard"
-						className="mx-2 whitespace-nowrap text-lg xl:text-xl bg-[length:0%_2px] bg-no-repeat bg-left-bottom transition-all duration-200 bg-gradient-to-r from-hackrpi-yellow to-hackrpi-yellow hover:bg-[length:100%_2px]"
+						className="mx-2 whitespace-nowrap text-lg xl:text-xl bg-[length:0%_2px] bg-no-repeat bg-left-bottom transition-all duration-200 bg-gradient-to-r from-hackrpi-yellow to-hackrpi-pink hover:bg-[length:100%_2px]"
 					>
 						2048 Leaderboard
 					</Link>
 					<Link
 						href="https://static.mlh.io/docs/mlh-code-of-conduct.pdf"
-						className="mx-2 whitespace-nowrap text-lg xl:text-xl bg-[length:0%_2px] bg-no-repeat bg-left-bottom transition-all duration-200 bg-gradient-to-r from-hackrpi-yellow to-hackrpi-yellow hover:bg-[length:100%_2px]"
+						className="mx-2 whitespace-nowrap text-lg xl:text-xl bg-[length:0%_2px] bg-no-repeat bg-left-bottom transition-all duration-200 bg-gradient-to-r from-hackrpi-yellow to-hackrpi-pink hover:bg-[length:100%_2px]"
 						target="_blank"
 					>
 						Code of Conduct

--- a/components/nav-bar/desktop/nav-bar-desktop.tsx
+++ b/components/nav-bar/desktop/nav-bar-desktop.tsx
@@ -7,7 +7,7 @@ import Link from "next/link";
 
 export default function DesktopNavBar({ links }: { links: NavGroup[] }) {
 	return (
-		<div className = "bg-gradient-to-r from-hackrpi-light-purple via-hackrpi-pink to-hackrpi-light-purple w-full h-16">
+		<div className="bg-gradient-to-r from-hackrpi-light-purple via-hackrpi-pink to-hackrpi-light-purple w-full h-16">
 			<div className="flex justify-center lg:justify-center items-center h-full">
 				<div className="flex items-center justify-center mr-4">
 					<Link href="/" className="w-fit whitespace-nowrap">

--- a/components/nav-bar/desktop/nav-group.tsx
+++ b/components/nav-bar/desktop/nav-group.tsx
@@ -4,11 +4,11 @@ import Link from "next/link";
 
 export default function NavGroup({ name, links }: { name: string; links: lin[] }) {
 	return (
-		<div className="dropdown dropdown-hover mx-2 whitespace-nowrap">
+		<div className="dropdown dropdown-hover mx-2 whitespace-nowrap text-lg xl:text-xl bg-[length:0%_2px] bg-no-repeat bg-left-bottom transition-all duration-200 bg-gradient-to-r from-hackrpi-yellow to-hackrpi-pink hover:bg-[length:100%_2px]">
 			<div
 				tabIndex={0}
 				role="button"
-				className="text-lg xl:text-xl bg-[length:0%_2px] bg-no-repeat bg-left-bottom transition-all duration-200 bg-gradient-to-r from-hackrpi-yellow to-hackrpi-yellow hover:bg-[length:100%_2px] focus:bg-[length:100%_4px] "
+				className="text-lg xl:text-xl bg-[length:0%_2px] bg-no-repeat bg-left-bottom transition-all duration-200 bg-gradient-to-r from-hackrpi-yellow to-hackrpi-yellow hover:bg-[length:100%_2px] focus:bg-[length:100%_4px]"
 			>
 				<Link href={links[0].href}>{name}</Link>
 			</div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
 			"devDependencies": {
 				"@aws-amplify/backend": "^1.14.2",
 				"@aws-amplify/backend-cli": "^1.4.12",
-				"@babel/core": "^7.26.9",
+				"@babel/core": "^7.26.10",
 				"@babel/preset-env": "^7.26.9",
 				"@babel/preset-react": "^7.26.3",
 				"@babel/preset-typescript": "^7.26.0",
@@ -19906,22 +19906,22 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.26.9",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.9.tgz",
-			"integrity": "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==",
+			"version": "7.26.10",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
+			"integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.26.2",
-				"@babel/generator": "^7.26.9",
+				"@babel/generator": "^7.26.10",
 				"@babel/helper-compilation-targets": "^7.26.5",
 				"@babel/helper-module-transforms": "^7.26.0",
-				"@babel/helpers": "^7.26.9",
-				"@babel/parser": "^7.26.9",
+				"@babel/helpers": "^7.26.10",
+				"@babel/parser": "^7.26.10",
 				"@babel/template": "^7.26.9",
-				"@babel/traverse": "^7.26.9",
-				"@babel/types": "^7.26.9",
+				"@babel/traverse": "^7.26.10",
+				"@babel/types": "^7.26.10",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -19937,14 +19937,14 @@
 			}
 		},
 		"node_modules/@babel/core/node_modules/@babel/generator": {
-			"version": "7.26.9",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.9.tgz",
-			"integrity": "sha512-kEWdzjOAUMW4hAyrzJ0ZaTOu9OmpyDIQicIh0zg0EEcEkYXZb2TjtBhnHi2ViX7PKwZqF4xwqfAm299/QMP3lg==",
+			"version": "7.26.10",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.10.tgz",
+			"integrity": "sha512-rRHT8siFIXQrAYOYqZQVsAr8vJ+cBNqcVAY6m5V8/4QqzaPl+zDBe6cLEPRDuNOUf3ww8RfJVlOyQMoSI+5Ang==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.26.9",
-				"@babel/types": "^7.26.9",
+				"@babel/parser": "^7.26.10",
+				"@babel/types": "^7.26.10",
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"jsesc": "^3.0.2"
@@ -19954,9 +19954,9 @@
 			}
 		},
 		"node_modules/@babel/core/node_modules/@babel/types": {
-			"version": "7.26.9",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
-			"integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+			"version": "7.26.10",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.10.tgz",
+			"integrity": "sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -20370,23 +20370,23 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.26.9",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.9.tgz",
-			"integrity": "sha512-Mz/4+y8udxBKdmzt/UjPACs4G3j5SshJJEFFKxlCGPydG4JAHXxjWjAwjd09tf6oINvl1VfMJo+nB7H2YKQ0dA==",
+			"version": "7.26.10",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.10.tgz",
+			"integrity": "sha512-UPYc3SauzZ3JGgj87GgZ89JVdC5dj0AoetR5Bw6wj4niittNyFh6+eOGonYvJ1ao6B8lEa3Q3klS7ADZ53bc5g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/template": "^7.26.9",
-				"@babel/types": "^7.26.9"
+				"@babel/types": "^7.26.10"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helpers/node_modules/@babel/types": {
-			"version": "7.26.9",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
-			"integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+			"version": "7.26.10",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.10.tgz",
+			"integrity": "sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -20398,13 +20398,13 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.26.9",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
-			"integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
+			"version": "7.26.10",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.10.tgz",
+			"integrity": "sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.26.9"
+				"@babel/types": "^7.26.10"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -20414,9 +20414,9 @@
 			}
 		},
 		"node_modules/@babel/parser/node_modules/@babel/types": {
-			"version": "7.26.9",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
-			"integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+			"version": "7.26.10",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.10.tgz",
+			"integrity": "sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -22015,17 +22015,17 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.26.9",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.9.tgz",
-			"integrity": "sha512-ZYW7L+pL8ahU5fXmNbPF+iZFHCv5scFak7MZ9bwaRPLUhHh7QQEMjZUg0HevihoqCM5iSYHN61EyCoZvqC+bxg==",
+			"version": "7.26.10",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.10.tgz",
+			"integrity": "sha512-k8NuDrxr0WrPH5Aupqb2LCVURP/S0vBEn5mK6iH+GIYob66U5EtoZvcdudR2jQ4cmTwhEwW1DLB+Yyas9zjF6A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.26.2",
-				"@babel/generator": "^7.26.9",
-				"@babel/parser": "^7.26.9",
+				"@babel/generator": "^7.26.10",
+				"@babel/parser": "^7.26.10",
 				"@babel/template": "^7.26.9",
-				"@babel/types": "^7.26.9",
+				"@babel/types": "^7.26.10",
 				"debug": "^4.3.1",
 				"globals": "^11.1.0"
 			},
@@ -22034,14 +22034,14 @@
 			}
 		},
 		"node_modules/@babel/traverse/node_modules/@babel/generator": {
-			"version": "7.26.9",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.9.tgz",
-			"integrity": "sha512-kEWdzjOAUMW4hAyrzJ0ZaTOu9OmpyDIQicIh0zg0EEcEkYXZb2TjtBhnHi2ViX7PKwZqF4xwqfAm299/QMP3lg==",
+			"version": "7.26.10",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.10.tgz",
+			"integrity": "sha512-rRHT8siFIXQrAYOYqZQVsAr8vJ+cBNqcVAY6m5V8/4QqzaPl+zDBe6cLEPRDuNOUf3ww8RfJVlOyQMoSI+5Ang==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.26.9",
-				"@babel/types": "^7.26.9",
+				"@babel/parser": "^7.26.10",
+				"@babel/types": "^7.26.10",
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"jsesc": "^3.0.2"
@@ -22051,9 +22051,9 @@
 			}
 		},
 		"node_modules/@babel/traverse/node_modules/@babel/types": {
-			"version": "7.26.9",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
-			"integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+			"version": "7.26.10",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.10.tgz",
+			"integrity": "sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 	"devDependencies": {
 		"@aws-amplify/backend": "^1.14.2",
 		"@aws-amplify/backend-cli": "^1.4.12",
-		"@babel/core": "^7.26.9",
+		"@babel/core": "^7.26.10",
 		"@babel/preset-env": "^7.26.9",
 		"@babel/preset-react": "^7.26.3",
 		"@babel/preset-typescript": "^7.26.0",


### PR DESCRIPTION
Updated all the header option links to have a uniform underlining gradient.
Only "Home" and "Hack XI" are left alone because you can't see their underline because they have drop down menus. 

<img width="1710" alt="Screenshot 2025-03-11 at 4 58 25 PM" src="https://github.com/user-attachments/assets/7aec8862-1abf-4031-9cea-8be758506c26" />
<img width="82" alt="Screenshot 2025-03-11 at 4 59 05 PM" src="https://github.com/user-attachments/assets/b825b96f-1189-41fe-96c8-761c1033ac34" />