### PR TITLE
Further styled leaderboard

### DIFF
--- a/app/2048/leaderboard/page.tsx
+++ b/app/2048/leaderboard/page.tsx
@@ -509,15 +509,15 @@ export default function Page() {
 				<h1 className="mt-28 text-center text-4xl font-modern text-hackrpi-orange">2048 Leaderboard</h1>
 				<table className="min-w-[80vw] mt-10 justify-inbetween table-auto w-full table table-zebra">
 					<thead>
-						<tr>
-							<th className="w-1/4 px-4 py-2 text-center font-retro text-hackrpi-yellow">Position</th>
-							<th className="w-1/3 px-4 py-2 text-center font-retro text-hackrpi-yellow">Username</th>
-							<th className="w-1/3 px-4 py-2 text-center font-retro text-hackrpi-yellow">Score</th>
-							{isDirector ? <th className="w-1/3 px-4 py-2 font-retro text-hackrpi-yellow">Delete</th> : null}
+						<tr className="text-white bg-hackrpi-yellow">
+							<th className="w-1/4 px-4 py-2 text-center font-retro text-white">Position</th>
+							<th className="w-1/3 px-4 py-2 text-center font-retro text-white">Username</th>
+							<th className="w-1/3 px-4 py-2 text-center font-retro text-white">Score</th>
+							{isDirector ? <th className="w-1/3 px-4 py-2 font-retro text-white bg-hackrpi-yellow">Delete</th> : null}
 						</tr>
 					</thead>
 
-					<tbody className="text-center">
+					<tbody className="text-center text-white font-retro bg-gradient-to-r from-hackrpi-dark-purple to-hackrpi-yellow">
 						{leaderboardEntries.map((entry, index) => (
 							<tr key={entry.id}>
 								<td className="px-y py-2">{index + 1}</td>


### PR DESCRIPTION
More styling on leaderboard page

I changed fonts, made it so the header of the table is yellow, changed entries to have a retro font, and made it so every other row is a gradient from purple to yellow

![image](https://github.com/user-attachments/assets/30e2fbe8-ac26-43e1-90a9-80fc8f3ec535)
