### PR TITLE
Leaderboard Footer Bug Fix

### DIFF
--- a/app/(with-layout)/2048/leaderboard/page.tsx
+++ b/app/(with-layout)/2048/leaderboard/page.tsx
@@ -505,7 +505,7 @@ export default function Page() {
 
 	return (
 		<div className="flex flex-col items-center justify-start w-full h-full">
-			<div className="flex-grow flex-shrink">
+			<div className="flex-grow flex-shrink basis-auto">
 				<h1 className="mt-28 text-center text-4xl font-modern text-hackrpi-orange">2048 Leaderboard</h1>
 				<table className="min-w-[80vw] mt-10 justify-inbetween table-auto w-full table table-zebra">
 					<thead>

--- a/app/(with-layout)/2048/leaderboard/page.tsx
+++ b/app/(with-layout)/2048/leaderboard/page.tsx
@@ -504,8 +504,8 @@ export default function Page() {
 	}, []);*/
 
 	return (
-		<div className="flex flex-col items-center justify-start w-full h-screen">
-			<div className="flex-grow flex-shrink basis-auto">
+		<div className="flex flex-col items-center justify-start w-full h-full">
+			<div className="flex-grow flex-shrink">
 				<h1 className="mt-28 text-center text-4xl font-modern text-hackrpi-orange">2048 Leaderboard</h1>
 				<table className="min-w-[80vw] mt-10 justify-inbetween table-auto w-full table table-zebra">
 					<thead>
@@ -541,9 +541,6 @@ export default function Page() {
 					</tbody>
 				</table>
 			</div>
-			<div className="flex-grow mt-24"></div>
-
-			<div className="absolute-bottom-0 w-full"></div>
 		</div>
 	);
 }


### PR DESCRIPTION
# Fixes Floating Footer on Leaderboard page

## Please briefly describe the changes made in your pull request below
Fixes #104, replaced "h-screen" style with "h-full", removed spacing divs at bottom of leaderboard

## If your changes made visual updates to the website, please add screenshot(s) below
<img width="1873" height="822" alt="image" src="https://github.com/user-attachments/assets/b1a7386c-9ea8-4681-b45f-ce6d4eadea6d" />
